### PR TITLE
Improve home page with sailing imagery

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -14,7 +14,7 @@ const customJestConfig = {
     '\\.(png|jpg|jpeg|gif|svg)$': '<rootDir>/__mocks__/fileMock.js',
   },
   setupFilesAfterEnv: [],
-  testPathIgnorePatterns: ['/node_modules/', '/.next/'],
+  testPathIgnorePatterns: ['/node_modules/', '/.next/', '/tests/playwright/', '/tests/smoke/'],
   testEnvironment: 'jest-environment-jsdom',
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
 };

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 40">
+  <style>
+    text { font-family: Arial, Helvetica, sans-serif; font-weight: bold; }
+  </style>
+  <text x="0" y="30" font-size="32" fill="#ca2128">V</text>
+  <text x="45" y="30" font-size="32" fill="#001F3F">15</text>
+</svg>

--- a/public/images/v15-boat.svg
+++ b/public/images/v15-boat.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300">
+  <polygon points="80,250 200,40 200,250" fill="#b3c7ff"/>
+  <polygon points="200,70 340,250 200,250" fill="#ffffff"/>
+  <path d="M70 250 h260 l-35 25 H105z" fill="#001F3F"/>
+</svg>

--- a/public/images/v15-logo.svg
+++ b/public/images/v15-logo.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 40">
+  <style>
+    text { font-family: Arial, Helvetica, sans-serif; font-weight: bold; }
+  </style>
+  <text x="0" y="30" font-size="32" fill="#ca2128">V</text>
+  <text x="45" y="30" font-size="32" fill="#001F3F">15</text>
+</svg>

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -6,7 +6,10 @@ export default function Navbar() {
   return (
     <header className="bg-navy-blue text-white">
       <nav className="container mx-auto flex items-center justify-between p-4">
-        <Link href="/" className="text-xl font-bold">V-15 Sailing</Link>
+        <Link href="/" className="text-xl font-bold flex items-center gap-2">
+          <img src="/images/v15-logo.svg" alt="Vanguard 15 logo" className="w-8 h-8" />
+          <span>V-15 Sailing</span>
+        </Link>
         <button
           type="button"
           className="sm:hidden focus:outline-none"

--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -1,0 +1,15 @@
+import { Html, Head, Main, NextScript } from 'next/document';
+
+export default function Document() {
+  return (
+    <Html>
+      <Head>
+        <link rel="icon" href="/favicon.svg" />
+      </Head>
+      <body className="bg-white text-gray-900">
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
+}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -7,11 +7,20 @@ export default function Home() {
         <title>V-15 Sailing</title>
         <meta name="description" content="Resources, parts, and regatta info for Vanguard 15 sailors" />
       </Head>
-      <section className="text-center py-32 md:py-40 bg-gradient-to-b from-sky-blue to-sunset-orange text-white">
-        <h1 className="text-5xl md:text-6xl font-extrabold mb-6 drop-shadow-lg">Supporting the Vanguard 15 Sailing Community</h1>
-        <p className="max-w-2xl mx-auto text-xl md:text-2xl font-light">
-          Find articles, parts recommendations, and upcoming regattas—all in one place.
-        </p>
+      <section className="relative text-center py-32 md:py-40 bg-gradient-to-b from-sky-blue to-sunset-orange text-white overflow-hidden">
+        <img
+          src="/images/v15-boat.svg"
+          alt="Vanguard 15 sailboat"
+          className="absolute inset-0 w-full h-full object-contain opacity-20 pointer-events-none"
+        />
+        <div className="relative z-10">
+          <h1 className="text-5xl md:text-6xl font-extrabold mb-6 drop-shadow-lg">
+            Supporting the Vanguard 15 Sailing Community
+          </h1>
+          <p className="max-w-2xl mx-auto text-xl md:text-2xl font-light">
+            Find articles, parts recommendations, and upcoming regattas—all in one place.
+          </p>
+        </div>
       </section>
     </>
   );


### PR DESCRIPTION
## Summary
- add Vanguard 15 logo and boat images
- display logo in the navbar
- overhaul home page hero with sailboat graphic
- add favicon support via `_document`
- ignore Playwright suites in Jest config

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882e31a874c832c92131229d64a7c64